### PR TITLE
Initial Implementation of Lock State. 

### DIFF
--- a/software/core/include/LockState.hpp
+++ b/software/core/include/LockState.hpp
@@ -1,0 +1,40 @@
+
+#ifndef LOCK_STATE_HPP
+#define LOCK_STATE_HPP
+
+#include "State.hpp"
+#include "Channel.hpp"
+
+
+struct LCMTypeLaunchTrigger{
+  bool state = false;
+
+  LCMTypeLaunchTrigger(bool state = false){
+    this->state = state;
+  }
+};
+
+
+class LockState: public State{
+
+  private:
+    States name;
+    Channel* launch_trigger_channel_ptr;
+    LCMTypeLaunchTrigger launch_trigger;
+
+  public:
+
+  //default constructor
+  LockState();
+
+  //primary constructor
+  LockState(States name);
+
+  //check channels
+  States run();
+
+  //destructor
+  ~LockState();
+};
+
+#endif

--- a/software/core/src/LockState.cpp
+++ b/software/core/src/LockState.cpp
@@ -1,0 +1,47 @@
+
+#include "LockState.hpp"
+
+//default constructor
+LockState::LockState():State(){}
+
+//[call the same systems check executed within the 'SYS_CHECK' state]
+// >>>
+bool run_systems_diagnostic_check(){ 
+  return true; 
+}
+// <<<
+
+
+//primary constructor
+LockState::LockState(States name):State(name){
+
+  this->name = name;
+  this->launch_trigger_channel_ptr = new Channel("primary_launch_trigger");
+  this->launch_trigger = LCMTypeLaunchTrigger();
+}
+
+
+//function to request data from States 
+States LockState::run(){
+
+  // >>> [Uncomment Once 'handle' implemented within channel class]
+  // this->launch_trigger_channel_ptr->handle(this->launch_trigger);
+  // <<<
+
+  if (this->launch_trigger.state){
+
+    //run systems diagnostic check, 
+    //if successful proceed to 'ARM', else 'DEBUG' state
+    if (run_systems_diagnostic_check()){
+      return ARM;
+    }
+    return DEBUG;
+  }
+  return LOCK;
+}
+
+
+//destructor
+LockState::~LockState(){
+  delete this->launch_trigger_channel_ptr;
+}


### PR DESCRIPTION
Created LockState.hpp and LockState.cpp within core/include and core/src respectively. 

Should we create static or dynamic instances of channels within state classes? I assume it would probably depend on whether states are reallocated every time a state change occurs within the state manager. 

Also I am a bit unclear as to the purpose of the channel.subscribe() method. Are we allocating new channel instances or receiving some sort of reference to an existing instance? If the latter, ignore the previous question. 